### PR TITLE
[docs] Add terminology section

### DIFF
--- a/docs/terminology/index.md
+++ b/docs/terminology/index.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Terminology
+permalink: /terminology
+nav_order: 8
+has_children: false
+has_toc: false
+---
+
+# Terminology used in GrimoireLab
+
+- **Dashboard** - refers to the collection of visualization under one name. For example,
+  the Overview dashboard in CHAOSS contains visualization that give a general feel of the
+  community and project health.
+
+- **Dashboards** - refers to all the dashboards present. You can access them through the
+  dashboards option in the sidebar. It's the 3rd icon on the GrimoireLab sidebar.
+
+- **Visualization** - A visualization is a graphical view of the data pulled
+  from an index. You can see all your visualization through the `Visualize`
+  option in the sidebar. It's the 2nd icon on the GrimoireLab sidebar.
+
+- **Index** - An index is a collection of JSON documents related to one particular data
+  source.
+
+- **Index-pattern** - An index pattern shows the different attributes contained in an
+  index or a set of them.
+
+- **Data-Source** - GrimoireLab supports many data-sources. They represent the platforms and
+  tools from where GrimoireLab can pull data to analyze.


### PR DESCRIPTION
This commit add the section related to
frequent terminologies used around GrimoireLab.
It contains the most obvious ones but more can be
added later on.

Signed-off-by: sevagenv <sevagenv@gmail.com>